### PR TITLE
Compute Delaunay triangulation using PDAL

### DIFF
--- a/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/DEMRasterSource.scala
+++ b/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/DEMRasterSource.scala
@@ -114,7 +114,7 @@ case class DEMRasterSource(
         val tile = DoubleArrayTile.empty(cols.toInt, rows.toInt)
 
         def rasterizeTriangle(tri: Triangle): Unit = {
-          val (a,b,c) = (tri.a, tri.b, tri.c)
+          val Triangle(a,b,c) = tri
 
           val v1x = pc.getX(a)
           val v1y = pc.getY(a)

--- a/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/DEMRasterSource.scala
+++ b/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/DEMRasterSource.scala
@@ -93,7 +93,7 @@ case class DEMRasterSource(
       threads    = threads
     ) ~ FilterDelaunay()
 
-    //logger.debug(expression.toPipelineConstructor.asJson.spaces4)
+    logger.debug(expression.asJson.spaces4)
 
     val pipeline = expression toPipeline
 

--- a/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/DEMRasterSource.scala
+++ b/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/DEMRasterSource.scala
@@ -84,14 +84,14 @@ case class DEMRasterSource(
       Proj4Transform(crs, metadata.crs),
       Reproject.Options.DEFAULT
     )
-    val bnds = srcBounds.extent
+    val bnds @ Extent(exmin, eymin, exmax, eymax) = srcBounds.extent
 
     val expression = ReadEpt(
       filename   = eptSource,
       resolution = gridExtent.cellSize.resolution.some,
       bounds     = s"([${bnds.xmin}, ${bnds.ymin}], [${bnds.xmax}, ${bnds.ymax}])".some,
       threads    = threads
-    )
+    ) ~ FilterDelaunay()
 
     logger.debug(expression.toPipelineConstructor.asJson.spaces4)
 
@@ -102,16 +102,124 @@ case class DEMRasterSource(
         pipeline.execute
 
         val pointViews = pipeline.getPointViews().asScala.toList
-        val viewSizes = pointViews.map(_.length)
-        val (nCoords, starts) = viewSizes.foldLeft(0 -> List.empty[Int]) { case ((acc, cum), v) => (v + acc, cum :+ acc) }
-        val coords = Array.ofDim[Coordinate](nCoords)
-        viewSizes.zip(starts).zip(pointViews).foreach { case ((n, z), pv) =>
-          val pc = pv.getPointCloud(DimType.X, DimType.Y, DimType.Z)
-          cfor(0)(_ < n, _ + 1) { i => coords(z + i) = pc.getCoordinate(i) }
+        assert(pointViews.length == 1, "Triangulation pipeline should have single resulting point view")
+
+        val pc = pointViews(0).getPointCloud(DimType.X, DimType.Y, DimType.Z)
+        val tris = pointViews(0).getTriangularMesh()
+
+        val w = gridExtent.cellwidth
+        val h = gridExtent.cellheight
+        val cols = bounds.width
+        val rows = bounds.height
+        val tile = DoubleArrayTile.empty(cols.toInt, rows.toInt)
+
+        def rasterizeTriangle(tri: Triangle): Unit = {
+          val (a,b,c) = (tri.a, tri.b, tri.c)
+
+          val v1x = pc.getX(a)
+          val v1y = pc.getY(a)
+          val v1z = pc.getZ(a)
+          val s1x = pc.getX(c)
+          val s1y = pc.getY(c)
+
+          val v2x = pc.getX(b)
+          val v2y = pc.getY(b)
+          val v2z = pc.getZ(b)
+          val s2x = pc.getX(a)
+          val s2y = pc.getY(a)
+
+          val v3x = pc.getX(c)
+          val v3y = pc.getY(c)
+          val v3z = pc.getZ(c)
+          val s3x = pc.getX(b)
+          val s3y = pc.getY(b)
+
+          val determinant =
+          (v2y - v3y) * (v1x - v3x) + (v3x - v2x) * (v1y - v3y)
+
+          val ymin =
+            math.min(v1y, math.min(v2y, v3y))
+          val ymax =
+              math.max(v1y, math.max(v2y, v3y))
+
+          val scanrow0 = math.max(math.ceil((ymin - eymin) / h - 0.5), 0)
+          var scany = eymin + scanrow0 * h + h / 2
+          while (scany < eymax && scany < ymax) {
+            // get x at y for edge
+            var xmin = Double.MinValue
+            var xmax = Double.MaxValue
+
+            if(s1y != v1y) {
+              val t = (scany - v1y) / (s1y - v1y)
+              val xAtY1 = v1x + t * (s1x - v1x)
+
+              if(v1y < s1y) {
+                // Lefty
+                if(xmin < xAtY1) { xmin = xAtY1 }
+              } else {
+                // Righty
+                if(xAtY1 < xmax) { xmax = xAtY1 }
+              }
+            }
+
+            if(s2y != v2y) {
+              val t = (scany - v2y) / (s2y - v2y)
+              val xAtY2 = v2x + t * (s2x - v2x)
+
+              if(v2y < s2y) {
+                // Lefty
+                if(xmin < xAtY2) { xmin = xAtY2 }
+              } else {
+                // Righty
+                if(xAtY2 < xmax) { xmax = xAtY2 }
+              }
+            }
+
+            if(s3y != v3y) {
+              val t = (scany - v3y) / (s3y - v3y)
+              val xAtY3 = v3x + t * (s3x - v3x)
+
+              if(v3y < s3y) {
+                // Lefty
+                if(xmin < xAtY3) { xmin = xAtY3 }
+              } else {
+                // Righty
+                if(xAtY3 < xmax) { xmax = xAtY3 }
+              }
+            }
+
+            val scancol0 = math.max(math.ceil((xmin - exmin) / w - 0.5), 0)
+            var scanx = exmin + scancol0 * w + w / 2
+            while (scanx < exmax && scanx < xmax) {
+              val col = ((scanx - exmin) / w).toInt
+              val row = ((eymax - scany) / h).toInt
+              if(0 <= col && col < cols &&
+                 0 <= row && row < rows) {
+
+                val z = {
+
+                  val lambda1 =
+                  ((v2y - v3y) * (scanx - v3x) + (v3x - v2x) * (scany - v3y)) / determinant
+
+                  val lambda2 =
+                  ((v3y - v1y) * (scanx - v3x) + (v1x - v3x) * (scany - v3y)) / determinant
+
+                  val lambda3 = 1.0 - lambda1 - lambda2
+
+                  lambda1 * v1z + lambda2 * v2z + lambda3 * v3z
+                }
+
+                tile.setDouble(col, row, z)
+              }
+
+              scanx += w
+            }
+
+            scany += h
+          }
         }
 
-        val dt = DelaunayTriangulation(coords)
-        val tile = DelaunayRasterizer.rasterizeDelaunayTriangulation(dt, srcBounds.toRasterExtent)
+        tris.asScala.foreach(rasterizeTriangle(_))
         Raster(MultibandTile(tile), targetRegion).some
       } else None
     } finally pipeline.close()
@@ -124,4 +232,6 @@ case class DEMRasterSource(
 
   def convert(targetCellType: TargetCellType): RasterSource =
     throw new UnsupportedOperationException("DEM height fields may only be of floating point type")
+
+
 }

--- a/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/DEMRasterSource.scala
+++ b/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/DEMRasterSource.scala
@@ -93,7 +93,7 @@ case class DEMRasterSource(
       threads    = threads
     ) ~ FilterDelaunay()
 
-    logger.debug(expression.toPipelineConstructor.asJson.spaces4)
+    //logger.debug(expression.toPipelineConstructor.asJson.spaces4)
 
     val pipeline = expression toPipeline
 


### PR DESCRIPTION
This PR shifts away from the GT Delaunay triangulator in favor of the one provided by PDAL.  We also borrow the facilities from GT to rasterize this new triangulation.