### PR TITLE
Fix Delaunay rasterization

### DIFF
--- a/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/DEMRasterSource.scala
+++ b/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/DEMRasterSource.scala
@@ -79,7 +79,7 @@ case class DEMRasterSource(
 
         pointViews.headOption.map { pv =>
           PDALTrianglesRasterizer
-            .native(pv, RasterExtent(targetRegion, bounds.width.toInt, bounds.height.toInt))
+            .apply(pv, RasterExtent(targetRegion, bounds.width.toInt, bounds.height.toInt))
             .mapTile(MultibandTile(_))
         }
       } else None

--- a/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/DEMReprojectRasterSource.scala
+++ b/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/DEMReprojectRasterSource.scala
@@ -116,7 +116,7 @@ case class DEMReprojectRasterSource(
           val pv = pointViews.head
           val sourceRaster =
             PDALTrianglesRasterizer
-              .native(pv, sourceRegion)
+              .apply(pv, sourceRegion)
               .mapTile(MultibandTile(_))
 
           val rr = implicitly[RasterRegionReproject[MultibandTile]]

--- a/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/DEMReprojectRasterSource.scala
+++ b/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/DEMReprojectRasterSource.scala
@@ -91,13 +91,15 @@ case class DEMReprojectRasterSource(
         rows = targetPixelBounds.height.toInt
       )
 
-      val sourceRegion = ReprojectRasterExtent(targetRegion, backTransform, Reproject.Options.DEFAULT)
+      /** Buffer the targetRegion to generate a buffered raster from a mesh to perform a more precise region reproject */
+      val bufferedTargetRegion = RasterExtent(targetRegion.extent.buffer(4 * targetRegion.cellwidth, 4 * targetRegion.cellheight), targetRegion.cellSize)
+      val bufferedSourceRegion = ReprojectRasterExtent(bufferedTargetRegion, backTransform, Reproject.Options.DEFAULT)
 
-      val Extent(exmin, eymin, exmax, eymax) = sourceRegion.extent
+      val Extent(exmin, eymin, exmax, eymax) = bufferedSourceRegion.extent
 
       val expression = ReadEpt(
         filename   = path.value,
-        resolution = sourceRegion.cellSize.resolution.some,
+        resolution = bufferedSourceRegion.cellSize.resolution.some,
         bounds     = s"([$exmin, $eymin], [$exmax, $eymax])".some,
         threads    = threads
       ) ~ FilterDelaunay()
@@ -116,7 +118,7 @@ case class DEMReprojectRasterSource(
           val pv = pointViews.head
           val sourceRaster =
             PDALTrianglesRasterizer
-              .apply(pv, sourceRegion)
+              .apply(pv, bufferedSourceRegion)
               .mapTile(MultibandTile(_))
 
           val rr = implicitly[RasterRegionReproject[MultibandTile]]

--- a/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/DEMResampleRasterSource.scala
+++ b/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/DEMResampleRasterSource.scala
@@ -116,7 +116,7 @@ case class DEMResampleRasterSource(
           val pv = pointViews.head
           val raster =
             PDALTrianglesRasterizer
-              .native(pv, targetRegion)
+              .apply(pv, targetRegion)
               .mapTile(MultibandTile(_))
               .resample(targetRegion.cols, targetRegion.rows, resampleMethod)
 

--- a/pointcloud/src/main/scala/geotrellis/pointcloud/raster/rasterize/triangles/PDALTrianglesRasterizer.scala
+++ b/pointcloud/src/main/scala/geotrellis/pointcloud/raster/rasterize/triangles/PDALTrianglesRasterizer.scala
@@ -73,7 +73,7 @@ object PDALTrianglesRasterizer {
 
       val scanrow0 = math.max(math.ceil((ymin - eymin) / h - 0.5), 0)
       var scany = eymin + scanrow0 * h + h / 2
-      while (scany < eymax && scany <= ymax) {
+      while (scany <= eymax && scany <= ymax) {
         // get x at y for edge
         var xmin = Double.MinValue
         var xmax = Double.MaxValue
@@ -119,7 +119,7 @@ object PDALTrianglesRasterizer {
 
         val scancol0 = math.max(math.ceil((xmin - exmin) / w - 0.5), 0)
         var scanx = exmin + scancol0 * w + w / 2
-        while (scanx < exmax && scanx <= xmax) {
+        while (scanx <= exmax && scanx <= xmax) {
           val col = ((scanx - exmin) / w).toInt
           val row = ((eymax - scany) / h).toInt
           if(0 <= col && col < cols &&

--- a/pointcloud/src/main/scala/geotrellis/pointcloud/raster/rasterize/triangles/PDALTrianglesRasterizer.scala
+++ b/pointcloud/src/main/scala/geotrellis/pointcloud/raster/rasterize/triangles/PDALTrianglesRasterizer.scala
@@ -73,7 +73,7 @@ object PDALTrianglesRasterizer {
 
       val scanrow0 = math.max(math.ceil((ymin - eymin) / h - 0.5), 0)
       var scany = eymin + scanrow0 * h + h / 2
-      while (scany < eymax && scany < ymax) {
+      while (scany < eymax && scany <= ymax) {
         // get x at y for edge
         var xmin = Double.MinValue
         var xmax = Double.MaxValue
@@ -119,7 +119,7 @@ object PDALTrianglesRasterizer {
 
         val scancol0 = math.max(math.ceil((xmin - exmin) / w - 0.5), 0)
         var scanx = exmin + scancol0 * w + w / 2
-        while (scanx < exmax && scanx < xmax) {
+        while (scanx < exmax && scanx <= xmax) {
           val col = ((scanx - exmin) / w).toInt
           val row = ((eymax - scany) / h).toInt
           if(0 <= col && col < cols &&

--- a/pointcloud/src/test/scala/geotrellis/pointcloud/raster/ept/DEMRasterSourceSpec.scala
+++ b/pointcloud/src/test/scala/geotrellis/pointcloud/raster/ept/DEMRasterSourceSpec.scala
@@ -17,7 +17,7 @@
 package geotrellis.pointcloud.raster.ept
 
 import geotrellis.layer._
-import geotrellis.proj4.{CRS, LatLng}
+import geotrellis.proj4.{CRS, LatLng, WebMercator}
 import geotrellis.raster.io.geotiff.GeoTiff
 import geotrellis.raster.resample.NearestNeighbor
 import geotrellis.raster.{CellSize, DefaultTarget, Dimensions, DoubleCellType, GridExtent, Raster, StringName, TileLayout}
@@ -103,26 +103,27 @@ class DEMRasterSourceSpec extends FunSpec with Matchers {
       ma shouldBe 2026.7 +- 2
     }
 
+    // https://github.com/geotrellis/geotrellis-pointcloud/issues/47
     ignore("rasterizer bug") {
       val ge = new GridExtent[Long](Extent(481968.0, 4390186.0, 482718.32558139536, 4390537.069767442), 6.883720930232645, 6.883720930227462, 109, 51)
       val rs = DEMRasterSource(catalog).resampleToRegion(ge)
       GeoTiff(rs.read().get, rs.crs).write("/tmp/test.tiff")
     }
 
-    it("rasterizer bug #2") {
-      val rs = DEMRasterSource(catalog)
+    // https://github.com/geotrellis/geotrellis-pointcloud/issues/47
+    ignore("rasterizer / reprojection bug") {
       val key = SpatialKey(27231, 49781)
       val ld =
         LayoutDefinition(Extent(-2.003750834278925E7, -2.003750834278925E7, 2.003750834278925E7, 2.003750834278925E7),
           TileLayout(131072,131072,256,256)
         )
 
-      val rsr =
+      val rs =
         DEMRasterSource(catalog)
-          .reproject(CRS.fromEpsgCode(3857), DefaultTarget)
+          .reproject(WebMercator, DefaultTarget)
           .tileToLayout(ld, NearestNeighbor)
 
-      GeoTiff(Raster(rsr.read(key).get, ld.mapTransform(key)), CRS.fromEpsgCode(3857)).write("/tmp/test#2.tiff")
+      GeoTiff(Raster(rs.read(key).get, ld.mapTransform(key)), WebMercator).write("/tmp/test-reproject.tiff")
     }
   }
 }


### PR DESCRIPTION
This PR brings up @jpolchlo Rasterization changes from here https://github.com/jpolchlo/geotrellis-pointcloud/commit/a5953b0f71916fb8132eac7b664eb8b609379951

Updates PDAL up to a version with the fixed rasterizer as well.
Fixed DEMReprojectRasterSource to generate a bit buffered rasterization to aboid possible problems with nn reprojection.

Closes https://github.com/geotrellis/geotrellis-pointcloud/issues/47