### PR TITLE
Simplify EPTMetadata build function

### DIFF
--- a/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/DEMRasterSource.scala
+++ b/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/DEMRasterSource.scala
@@ -29,6 +29,11 @@ import org.log4s._
 
 import scala.collection.JavaConverters._
 
+/**
+  * [[DEMRasterSource]] doesn't use [[OverviewStrategy]].
+  * At this point, it relies on the EPTReader logic:
+  * https://github.com/PDAL/PDAL/blob/2.1.0/io/EptReader.cpp#L293-L318
+  */
 case class DEMRasterSource(
   path: EPTPath,
   resampleTarget: ResampleTarget = DefaultTarget,

--- a/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/DEMReprojectRasterSource.scala
+++ b/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/DEMReprojectRasterSource.scala
@@ -31,6 +31,11 @@ import org.log4s._
 
 import scala.collection.JavaConverters._
 
+/**
+  * [[DEMReprojectRasterSource]] doesn't use [[OverviewStrategy]].
+  * At this point, it relies on the EPTReader logic:
+  * https://github.com/PDAL/PDAL/blob/2.1.0/io/EptReader.cpp#L293-L318
+  */
 case class DEMReprojectRasterSource(
   path: EPTPath,
   crs: CRS,
@@ -44,7 +49,7 @@ case class DEMReprojectRasterSource(
   @transient private[this] lazy val logger = getLogger
 
   lazy val baseMetadata: EPTMetadata = sourceMetadata.getOrElse(EPTMetadata(path.value))
-  lazy val metadata: EPTMetadata = baseMetadata.copy(gridExtent = gridExtent)
+  lazy val metadata: EPTMetadata = baseMetadata.copy(crs = crs, gridExtent = gridExtent)
 
   protected lazy val baseCRS: CRS = baseMetadata.crs
   protected lazy val baseGridExtent: GridExtent[Long] = baseMetadata.gridExtent

--- a/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/DEMReprojectRasterSource.scala
+++ b/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/DEMReprojectRasterSource.scala
@@ -145,7 +145,3 @@ case class DEMReprojectRasterSource(
   def convert(targetCellType: TargetCellType): RasterSource =
     throw new UnsupportedOperationException("DEM height fields may only be of floating point type")
 }
-
-object DEMReprojectRasterSource {
-
-}

--- a/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/DEMResampleRasterSource.scala
+++ b/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/DEMResampleRasterSource.scala
@@ -31,7 +31,6 @@ import org.log4s._
 
 import scala.collection.JavaConverters._
 
-/** TODO: replace it with io.pdal.pipeline.FilterReproject */
 case class DEMResampleRasterSource(
   path: EPTPath,
   resampleTarget: ResampleTarget = DefaultTarget,
@@ -133,6 +132,4 @@ case class DEMResampleRasterSource(
 
   def convert(targetCellType: TargetCellType): RasterSource =
     throw new UnsupportedOperationException("DEM height fields may only be of floating point type")
-
-
 }

--- a/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/DEMResampleRasterSource.scala
+++ b/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/DEMResampleRasterSource.scala
@@ -31,6 +31,11 @@ import org.log4s._
 
 import scala.collection.JavaConverters._
 
+/**
+  * [[DEMResampleRasterSource]] doesn't use [[OverviewStrategy]].
+  * At this point, it relies on the EPTReader logic:
+  * https://github.com/PDAL/PDAL/blob/2.1.0/io/EptReader.cpp#L293-L318
+  */
 case class DEMResampleRasterSource(
   path: EPTPath,
   resampleTarget: ResampleTarget = DefaultTarget,

--- a/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/EPTMetadata.scala
+++ b/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/EPTMetadata.scala
@@ -24,6 +24,7 @@ import _root_.io.circe.parser._
 import cats.instances.long._
 import cats.instances.map._
 import cats.syntax.semigroup._
+import cats.syntax.either._
 
 import java.net.URI
 
@@ -43,7 +44,7 @@ object EPTMetadata {
   def pointsInLevels(base: URI, key: String): Map[Int, Long] = {
     val rr = RangeReader(base.resolve(s"ept-hierarchy/$key.json").toString)
     val raw = new String(rr.readAll)
-    val Right(json) = parse(raw)
+    val json = parse(raw).valueOr(throw _)
     val table = json.asObject.get.toList.toMap.mapValues(_.toString.toLong)
 
     val recurseKeys = table.filter(_._2 == -1).keys.toList
@@ -53,11 +54,15 @@ object EPTMetadata {
     nested.fold(joined)(_ combine _)
   }
 
-  def tree(source: String): EPTMetadata = {
+  def apply(source: String, withHierarchy: Boolean = false): EPTMetadata = {
     val src = if (source.endsWith("/")) source else s"$source/"
     val raw = Raw(src)
-    val counts = pointsInLevels(new URI(src), "0-0-0-0")
-    val maxDepth = counts.keys.max
+    val (counts, maxDepth) = {
+      if(withHierarchy) {
+        val cnts = pointsInLevels(new URI(src), "0-0-0-0").toList.sorted
+        cnts -> cnts.last._1
+      } else Map.empty[Int, Long] -> 0
+    }
 
     // https://github.com/PDAL/PDAL/blob/2.1.0/io/EptReader.cpp#L293-L318
     val resolutions = (0 to maxDepth).toList.map { l =>
@@ -72,42 +77,7 @@ object EPTMetadata {
       resolutions,
       Map(
         "points" -> raw.points.toString,
-        "pointsInLevels" -> counts.toSeq.sorted.map(_._2).mkString(","),
-        "minz" -> raw.boundsConforming(2).toString,
-        "maxz" -> raw.boundsConforming(5).toString
-      )
-    )
-  }
-
-  def pointsInLevel(base: URI, key: String): Map[Int, Long] = {
-    val rr = RangeReader(base.resolve(s"ept-hierarchy/$key.json").toString)
-    val raw = new String(rr.readAll)
-    val Right(json) = parse(raw)
-    val table = json.asObject.get.toList.toMap.mapValues(_.toString.toLong)
-    val recurseKeys = table.filter(_._2 == -1).keys.toList
-    (table -- recurseKeys).groupBy(_._1.split("-").head.toInt).mapValues(_.values.sum)
-  }
-
-  def apply(source: String): EPTMetadata = {
-    val src = if (source.endsWith("/")) source else s"$source/"
-    val raw = Raw(src)
-    val counts = pointsInLevel(new URI(src), "0-0-0-0")
-    val maxDepth = counts.keys.max
-
-    // https://github.com/PDAL/PDAL/blob/2.1.0/io/EptReader.cpp#L293-L318
-    val resolutions = (0 to maxDepth).toList.map { l =>
-      CellSize((raw.extent.width / raw.span) / math.pow(2, l), (raw.extent.height / raw.span) / math.pow(2, l))
-    }
-
-    EPTMetadata(
-      StringName(src),
-      raw.srs.toCRS(),
-      DoubleCellType,
-      GridExtent[Long](raw.extent, raw.span, raw.span),
-      resolutions,
-      Map(
-        "points" -> raw.points.toString,
-        "pointsInLevels" -> counts.toSeq.sorted.map(_._2).mkString(","),
+        "pointsInLevels" -> counts.map(_._2).mkString(","),
         "minz" -> raw.boundsConforming(2).toString,
         "maxz" -> raw.boundsConforming(5).toString
       )

--- a/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/EPTMetadata.scala
+++ b/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/EPTMetadata.scala
@@ -59,6 +59,7 @@ object EPTMetadata {
     val counts = pointsInLevels(new URI(src), "0-0-0-0")
     val maxDepth = counts.keys.max
 
+    // https://github.com/PDAL/PDAL/blob/2.1.0/io/EptReader.cpp#L293-L318
     val resolutions = (0 to maxDepth).toList.map { l =>
       CellSize((raw.extent.width / raw.span) / math.pow(2, l), (raw.extent.height / raw.span) / math.pow(2, l))
     }
@@ -93,6 +94,7 @@ object EPTMetadata {
     val counts = pointsInLevel(new URI(src), "0-0-0-0")
     val maxDepth = counts.keys.max
 
+    // https://github.com/PDAL/PDAL/blob/2.1.0/io/EptReader.cpp#L293-L318
     val resolutions = (0 to maxDepth).toList.map { l =>
       CellSize((raw.extent.width / raw.span) / math.pow(2, l), (raw.extent.height / raw.span) / math.pow(2, l))
     }

--- a/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/SRS.scala
+++ b/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/SRS.scala
@@ -17,13 +17,14 @@
 package geotrellis.pointcloud.raster.ept
 
 import geotrellis.proj4.{CRS, LatLng}
-
 import io.circe.generic.JsonCodec
+
+import scala.util.Try
 
 @JsonCodec
 case class SRS(authority: Option[String], horizontal: Option[String], vertical: Option[String], wkt: Option[String]) {
   def toCRS(defaultCRS: CRS = LatLng): CRS = {
-    val parsed: Option[CRS] = for { txt <- wkt; crs <- CRS.fromWKT(txt) } yield crs
+    val parsed: Option[CRS] = for { txt <- wkt; crs <- Try { CRS.fromWKT(txt) }.toOption.flatten } yield crs
     val fromCode = authority.filter(_.toLowerCase == "epsg").fold(defaultCRS) { _ =>
       horizontal.map(epsg => CRS.fromEpsgCode(epsg.toInt)).getOrElse(defaultCRS)
     }

--- a/pointcloud/src/test/scala/geotrellis/pointcloud/raster/ept/DEMRasterSourceSpec.scala
+++ b/pointcloud/src/test/scala/geotrellis/pointcloud/raster/ept/DEMRasterSourceSpec.scala
@@ -36,8 +36,8 @@ class DEMRasterSourceSpec extends FunSpec with RasterMatchers {
         crs         = CRS.fromEpsgCode(26913),
         cellType    = DoubleCellType,
         gridExtent  = new GridExtent(Extent(481968.0, 4390186.0, 482856.0, 4391074.0), 6.9375, 6.9375, 128, 128),
-        resolutions = List(CellSize(6.9375, 6.9375), CellSize(3.46875, 3.46875), CellSize(1.734375, 1.734375), CellSize(0.8671875, 0.8671875), CellSize(0.43359375, 0.43359375)),
-        attributes  = Map("points" -> "4004326", "pointsInLevels" -> "15366,186189,465711,2297397,1039663", "minz" -> "1843.0", "maxz" -> "2030.0")
+        resolutions = CellSize(6.9375, 6.9375) :: Nil,
+        attributes  = Map("points" -> "4004326", "pointsInLevels" -> "", "minz" -> "1843.0", "maxz" -> "2030.0")
       )
 
       val rs = DEMRasterSource(catalog)
@@ -65,8 +65,8 @@ class DEMRasterSourceSpec extends FunSpec with RasterMatchers {
         crs         = CRS.fromEpsgCode(26913),
         cellType    = DoubleCellType,
         gridExtent  = new GridExtent(Extent(481968.0, 4390186.0, 482856.0, 4391074.0),8.88, 8.88,100, 100),
-        resolutions = List(CellSize(6.9375, 6.9375), CellSize(3.46875, 3.46875), CellSize(1.734375, 1.734375), CellSize(0.8671875, 0.8671875), CellSize(0.43359375, 0.43359375)),
-        attributes  = Map("points" -> "4004326", "pointsInLevels" -> "15366,186189,465711,2297397,1039663", "minz" -> "1843.0", "maxz" -> "2030.0")
+        resolutions = CellSize(6.9375, 6.9375) :: Nil,
+        attributes  = Map("points" -> "4004326", "pointsInLevels" -> "", "minz" -> "1843.0", "maxz" -> "2030.0")
       )
 
       val rs = DEMRasterSource(catalog).resample(100, 100)
@@ -91,11 +91,11 @@ class DEMRasterSourceSpec extends FunSpec with RasterMatchers {
     it("should reproject RasterSource") {
       val expectedMetadata: EPTMetadata = EPTMetadata(
         name        = "src/test/resources/red-rocks/",
-        crs         = CRS.fromEpsgCode(26913),
+        crs         = LatLng,
         cellType    = DoubleCellType,
         gridExtent  = new GridExtent(Extent(-105.21023644880934, 39.661268543413485, -105.19987676348154, 39.669309977479124), 7.244535194267097E-5,7.244535194267097E-5, 143, 111),
-        resolutions = List(CellSize(6.9375, 6.9375), CellSize(3.46875, 3.46875), CellSize(1.734375, 1.734375), CellSize(0.8671875, 0.8671875), CellSize(0.43359375, 0.43359375)),
-        attributes  = Map("points" -> "4004326", "pointsInLevels" -> "15366,186189,465711,2297397,1039663", "minz" -> "1843.0", "maxz" -> "2030.0")
+        resolutions = CellSize(6.9375, 6.9375) :: Nil,
+        attributes  = Map("points" -> "4004326", "pointsInLevels" -> "", "minz" -> "1843.0", "maxz" -> "2030.0")
       )
 
       val rs = DEMRasterSource(catalog).reproject(LatLng)

--- a/pointcloud/src/test/scala/geotrellis/pointcloud/raster/ept/DEMRasterSourceSpec.scala
+++ b/pointcloud/src/test/scala/geotrellis/pointcloud/raster/ept/DEMRasterSourceSpec.scala
@@ -28,22 +28,23 @@ import org.scalatest._
 
 class DEMRasterSourceSpec extends FunSpec with RasterMatchers {
   val catalog: String = "src/test/resources/red-rocks"
-  val expecedMetadata: EPTMetadata = EPTMetadata(
-    name        = "src/test/resources/red-rocks/",
-    crs         = CRS.fromEpsgCode(26913),
-    cellType    = DoubleCellType,
-    gridExtent  = new GridExtent(Extent(481968.0, 4390186.0, 482856.0, 4391074.0), 6.9375, 6.9375, 128, 128),
-    resolutions = List(CellSize(6.9375, 6.9375), CellSize(3.46875, 3.46875), CellSize(1.734375, 1.734375), CellSize(0.8671875, 0.8671875), CellSize(0.43359375, 0.43359375)),
-    attributes  = Map("points" -> "4004326", "pointsInLevels" -> "15366,186189,465711,2297397,1039663", "minz" -> "1843.0", "maxz" -> "2030.0")
-  )
 
   describe("DEMRasterSourceSpec") {
     it("should read from the EPT catalog") {
+      val expectedMetadata: EPTMetadata = EPTMetadata(
+        name        = "src/test/resources/red-rocks/",
+        crs         = CRS.fromEpsgCode(26913),
+        cellType    = DoubleCellType,
+        gridExtent  = new GridExtent(Extent(481968.0, 4390186.0, 482856.0, 4391074.0), 6.9375, 6.9375, 128, 128),
+        resolutions = List(CellSize(6.9375, 6.9375), CellSize(3.46875, 3.46875), CellSize(1.734375, 1.734375), CellSize(0.8671875, 0.8671875), CellSize(0.43359375, 0.43359375)),
+        attributes  = Map("points" -> "4004326", "pointsInLevels" -> "15366,186189,465711,2297397,1039663", "minz" -> "1843.0", "maxz" -> "2030.0")
+      )
+
       val rs = DEMRasterSource(catalog)
 
-      rs.metadata shouldBe expecedMetadata
-      rs.gridExtent shouldBe expecedMetadata.gridExtent
-      rs.crs shouldBe expecedMetadata.crs
+      rs.metadata shouldBe expectedMetadata
+      rs.gridExtent shouldBe expectedMetadata.gridExtent
+      rs.crs shouldBe expectedMetadata.crs
 
       val res = rs.read()
       res.nonEmpty shouldBe true
@@ -59,11 +60,20 @@ class DEMRasterSourceSpec extends FunSpec with RasterMatchers {
     }
 
     it("should resample RasterSource") {
+      val expectedMetadata: EPTMetadata = EPTMetadata(
+        name        = "src/test/resources/red-rocks/",
+        crs         = CRS.fromEpsgCode(26913),
+        cellType    = DoubleCellType,
+        gridExtent  = new GridExtent(Extent(481968.0, 4390186.0, 482856.0, 4391074.0),8.88, 8.88,100, 100),
+        resolutions = List(CellSize(6.9375, 6.9375), CellSize(3.46875, 3.46875), CellSize(1.734375, 1.734375), CellSize(0.8671875, 0.8671875), CellSize(0.43359375, 0.43359375)),
+        attributes  = Map("points" -> "4004326", "pointsInLevels" -> "15366,186189,465711,2297397,1039663", "minz" -> "1843.0", "maxz" -> "2030.0")
+      )
+
       val rs = DEMRasterSource(catalog).resample(100, 100)
 
-      rs.metadata shouldBe expecedMetadata
-      rs.gridExtent shouldBe new GridExtent(Extent(481968.0, 4390186.0, 482856.0, 4391074.0),8.88, 8.88,100, 100)
-      rs.crs shouldBe expecedMetadata.crs
+      rs.metadata shouldBe expectedMetadata
+      rs.gridExtent shouldBe expectedMetadata.gridExtent
+      rs.crs shouldBe expectedMetadata.crs
 
       val res = rs.read()
       res.nonEmpty shouldBe true
@@ -79,10 +89,19 @@ class DEMRasterSourceSpec extends FunSpec with RasterMatchers {
     }
 
     it("should reproject RasterSource") {
+      val expectedMetadata: EPTMetadata = EPTMetadata(
+        name        = "src/test/resources/red-rocks/",
+        crs         = CRS.fromEpsgCode(26913),
+        cellType    = DoubleCellType,
+        gridExtent  = new GridExtent(Extent(-105.21023644880934, 39.661268543413485, -105.19987676348154, 39.669309977479124), 7.244535194267097E-5,7.244535194267097E-5, 143, 111),
+        resolutions = List(CellSize(6.9375, 6.9375), CellSize(3.46875, 3.46875), CellSize(1.734375, 1.734375), CellSize(0.8671875, 0.8671875), CellSize(0.43359375, 0.43359375)),
+        attributes  = Map("points" -> "4004326", "pointsInLevels" -> "15366,186189,465711,2297397,1039663", "minz" -> "1843.0", "maxz" -> "2030.0")
+      )
+
       val rs = DEMRasterSource(catalog).reproject(LatLng)
 
-      rs.metadata shouldBe expecedMetadata
-      rs.gridExtent shouldBe new GridExtent(Extent(-105.21023644880934, 39.661268543413485, -105.19987676348154, 39.669309977479124), 7.244535194267097E-5,7.244535194267097E-5, 143, 111)
+      rs.metadata shouldBe expectedMetadata
+      rs.gridExtent shouldBe expectedMetadata.gridExtent
       rs.crs shouldBe LatLng
 
       val res = rs.read()

--- a/pointcloud/src/test/scala/geotrellis/pointcloud/spark/dem/PointCloudDemSpec.scala
+++ b/pointcloud/src/test/scala/geotrellis/pointcloud/spark/dem/PointCloudDemSpec.scala
@@ -25,12 +25,9 @@ import geotrellis.vector.Extent
 
 import org.scalatest._
 
-class PointCloudDemSpec extends FunSpec
-  with Matchers
-  with PointCloudTestEnvironment {
+class PointCloudDemSpec extends FunSpec with Matchers with PointCloudTestEnvironment {
 
   describe("PointCloud DEM support") {
-
     val min = { (a: Double, b: Double) => math.min(a, b) }
     val max = { (a: Double, b: Double) => math.max(a, b) }
     val rdd = HadoopPointCloudRDD(lasPath).flatMap(_._2)
@@ -44,8 +41,8 @@ class PointCloudDemSpec extends FunSpec
 
     it("should be able to produce a tile") {
       val length = cloud.length
-      val xs = (0 until length).map({ i => cloud.getDouble(i, "X") })
-      val ys = (0 until length).map({ i => cloud.getDouble(i, "Y") })
+      val xs = (0 until length).map { i => cloud.getDouble(i, "X") }
+      val ys = (0 until length).map { i => cloud.getDouble(i, "Y") }
       val xmin = xs.reduce(min)
       val xmax = xs.reduce(max)
       val ymin = ys.reduce(min)


### PR DESCRIPTION
This PR address #60 and introduces a EPTMetadata function that does not read recursively all the entwine hierarchy files.

Fixes https://github.com/geotrellis/geotrellis-pointcloud/issues/60