### PR TITLE
Add an explicit PointViews removal

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -83,8 +83,8 @@ lazy val commonSettings = Seq(
   resolvers ++= Seq(
     Resolver.sonatypeRepo("releases"),
     Resolver.sonatypeRepo("snapshots"),
-    "Locationtech Releases" at "https://repo.locationtech.org/content/groups/releases",
-    "Locationtech Snapshots" at "https://repo.locationtech.org/content/groups/snapshots"
+    "eclipse-releases" at "https://repo.eclipse.org/content/groups/releases",
+    "eclipse-snapshots" at "https://repo.eclipse.org/content/groups/snapshots"
   ),
   Global / cancelable := true,
   Test / fork := true,

--- a/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/IDWRasterSource.scala
+++ b/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/IDWRasterSource.scala
@@ -84,16 +84,17 @@ case class IDWRasterSource(
         val pointViews = pipeline.getPointViews().asScala.toList
         assert(pointViews.length == 1, "Triangulation pipeline should have single resulting point view")
 
-
         pointViews.headOption.map { pv =>
-          IDWRasterizer(
-            pv,
-            RasterExtent(
-              targetRegion,
-              bounds.width.toInt,
-              bounds.height.toInt
-            )
-          )
+          try {
+            IDWRasterizer(
+              pv,
+              RasterExtent(
+                targetRegion,
+                bounds.width.toInt,
+                bounds.height.toInt
+              )
+            ).mapTile(MultibandTile(_))
+          } finally pv.close()
         }
       } else None
     } finally pipeline.close()

--- a/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/IDWReprojectRasterSource.scala
+++ b/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/IDWReprojectRasterSource.scala
@@ -122,14 +122,17 @@ case class IDWReprojectRasterSource(
           val pointViews = pipeline.getPointViews().asScala.toList
           assert(pointViews.length == 1, "Triangulation pipeline should have single resulting point view")
 
-          val sourceRaster = IDWRasterizer(
-            pointViews.head,
-            RasterExtent(
-              bufferedSourceRegion.extent,
-              bounds.width.toInt,
-              bounds.height.toInt
-            )
-          )
+          val pv = pointViews.head
+          val sourceRaster = try {
+            IDWRasterizer(
+              pv,
+              RasterExtent(
+                bufferedSourceRegion.extent,
+                bounds.width.toInt,
+                bounds.height.toInt
+              )
+            ).mapTile(MultibandTile(_))
+          } finally pv.close()
 
           val rr = implicitly[RasterRegionReproject[MultibandTile]]
           val result = rr.regionReproject(

--- a/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/IDWResampleRasterSource.scala
+++ b/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/IDWResampleRasterSource.scala
@@ -120,14 +120,17 @@ case class IDWResampleRasterSource(
           val pointViews = pipeline.getPointViews().asScala.toList
           assert(pointViews.length == 1, "Triangulation pipeline should have single resulting point view")
 
-          val raster = IDWRasterizer(
-            pointViews.head,
-            RasterExtent(
-              targetRegion.extent,
-              bounds.width.toInt,
-              bounds.width.toInt
-            )
-          )
+          val pv = pointViews.head
+          val raster = try {
+            IDWRasterizer(
+              pv,
+              RasterExtent(
+                targetRegion.extent,
+                bounds.width.toInt,
+                bounds.width.toInt
+              )
+            ).mapTile(MultibandTile(_))
+          } finally pv.close()
 
           convertRaster(raster).some
         } else None

--- a/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/TINRasterSource.scala
+++ b/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/TINRasterSource.scala
@@ -83,9 +83,11 @@ case class TINRasterSource(
         assert(pointViews.length == 1, "Triangulation pipeline should have single resulting point view")
 
         pointViews.headOption.map { pv =>
-          PDALTrianglesRasterizer
-            .native(pv, RasterExtent(targetRegion, bounds.width.toInt, bounds.height.toInt))
-            .mapTile(MultibandTile(_))
+          try {
+            PDALTrianglesRasterizer
+              .native(pv, RasterExtent(targetRegion, bounds.width.toInt, bounds.height.toInt))
+              .mapTile(MultibandTile(_))
+          } finally pv.close()
         }
       } else None
     } finally pipeline.close()

--- a/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/TINReprojectRasterSource.scala
+++ b/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/TINReprojectRasterSource.scala
@@ -127,10 +127,11 @@ case class TINReprojectRasterSource(
           assert(pointViews.length == 1, "Triangulation pipeline should have single resulting point view")
 
           val pv = pointViews.head
-          val sourceRaster =
+          val sourceRaster = try {
             PDALTrianglesRasterizer
               .native(pv, bufferedSourceRegion)
               .mapTile(MultibandTile(_))
+          } finally pv.close()
 
           val rr = implicitly[RasterRegionReproject[MultibandTile]]
           val result = rr.regionReproject(

--- a/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/TINResampleRasterSource.scala
+++ b/pointcloud/src/main/scala/geotrellis/pointcloud/raster/ept/TINResampleRasterSource.scala
@@ -119,11 +119,12 @@ case class TINResampleRasterSource(
           assert(pointViews.length == 1, "Triangulation pipeline should have single resulting point view")
 
           val pv = pointViews.head
-          val raster =
+          val raster = try {
             PDALTrianglesRasterizer
               .native(pv, targetRegion)
               .mapTile(MultibandTile(_))
               .resample(targetRegion.cols, targetRegion.rows, resampleMethod)
+          } finally pv.close()
 
           convertRaster(raster).some
         } else None

--- a/pointcloud/src/main/scala/geotrellis/pointcloud/raster/rasterize/points/IDWRasterizer.scala
+++ b/pointcloud/src/main/scala/geotrellis/pointcloud/raster/rasterize/points/IDWRasterizer.scala
@@ -18,16 +18,16 @@ package geotrellis.pointcloud.raster.rasterize.points
 
 import geotrellis.raster._
 import geotrellis.raster.interpolation._
-import geotrellis.vector.{Extent, Point, PointFeature}
-import _root_.io.pdal.{DimType, PointView}
+import geotrellis.vector.{Point, PointFeature}
 
+import _root_.io.pdal.{DimType, PointView}
 import spire.syntax.cfor._
 
 object IDWRasterizer {
-  def apply(pv: PointView, re: RasterExtent, radiusMultiplier: Double = 1.5, cellType: CellType = DoubleConstantNoDataCellType): Raster[MultibandTile] = {
+  def apply(pv: PointView, re: RasterExtent, radiusMultiplier: Double = 1.5, cellType: CellType = DoubleConstantNoDataCellType): Raster[Tile] = {
     val pc = pv.getPointCloud(Array(DimType.X, DimType.Y, DimType.Z))
     val features = Array.ofDim[PointFeature[Double]](pc.length)
-    cfor(0)(_ < pc.length, _ + 1){ i =>
+    cfor(0)(_ < pc.length, _ + 1) { i =>
       features(i) = PointFeature[Double](Point(pc.getX(i), pc.getY(i)), pc.getZ(i))
     }
 
@@ -41,13 +41,11 @@ object IDWRasterizer {
         InverseDistanceWeighted.Options(
           radius,
           radius,
-          0.0,  // rotation
-          3.0,  // weighting power
-          0.0,  // smoothing factor
-          re.cellSize.resolution/2, //equal weight radius
+          0.0, // rotation
+          3.0, // weighting power
+          0.0, // smoothing factor
+          re.cellSize.resolution / 2, //equal weight radius
           cellType
         ))
-    .mapTile(MultibandTile(_))
   }
-
 }


### PR DESCRIPTION
This PR adds an explici PointView.close after each read to free the C memory explicitly without relying on a Java GC.